### PR TITLE
Fix minimum and maximum output exceeding availability

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -28,8 +28,8 @@ time_parameters:
 
 # 3) Set input and output data paths
 input_output_parameters:
-    path_folder_input: "../inputs/"
-    path_folder_output: "../results/"
+    path_folder_input: "./inputs/"
+    path_folder_output: "./results/"
 
 # 4) Set rolling horizon parameters (optional)
 rolling_horizon_parameters:

--- a/config.yml
+++ b/config.yml
@@ -28,8 +28,8 @@ time_parameters:
 
 # 3) Set input and output data paths
 input_output_parameters:
-    path_folder_input: "./inputs/"
-    path_folder_output: "./results/"
+    path_folder_input: "../inputs/"
+    path_folder_output: "../results/"
 
 # 4) Set rolling horizon parameters (optional)
 rolling_horizon_parameters:

--- a/pommesdispatch/model_funcs/subroutines.py
+++ b/pommesdispatch/model_funcs/subroutines.py
@@ -814,6 +814,7 @@ def set_min_load_and_gradient_profile(
     min_load_column,
     gradient_ts,
     gradient_column,
+    availability_ts="transformers_availability_ts",
 ):
     """Set the min load and gradient profile of a transformer
 
@@ -832,7 +833,7 @@ def set_min_load_and_gradient_profile(
     dm : :class:`DispatchModel`
         The dispatch model that is considered
 
-    min_loads_ts : str
+    min_load_ts : str
         Dictionary key for the minimum load time series DataFrame
 
     min_load_column : str
@@ -843,14 +844,23 @@ def set_min_load_and_gradient_profile(
 
     gradient_column : str
         Name of the column to use for assigning the gradient profile
+
+    availability_ts : str
+        Name of the column to use for limiting minimum output with current
+        availability
     """
     outflow_args_el["min"] = (
-        input_data[min_load_ts]
-        .loc[
-            dm.start_time : dm.end_time,
-            min_load_column,
-        ]
-        .to_numpy()
+        np.minimum(
+            input_data[min_load_ts]
+            .loc[
+                dm.start_time : dm.end_time,
+                min_load_column,
+            ]
+            .to_numpy(),
+            input_data[availability_ts].loc[
+                dm.start_time : dm.end_time, "values"
+            ].to_numpy() - 0.01
+        )
     )
     outflow_args_el["positive_gradient"]["ub"] = (
         input_data[gradient_ts]

--- a/pommesdispatch/model_funcs/subroutines.py
+++ b/pommesdispatch/model_funcs/subroutines.py
@@ -849,18 +849,17 @@ def set_min_load_and_gradient_profile(
         Name of the column to use for limiting minimum output with current
         availability
     """
-    outflow_args_el["min"] = (
-        np.minimum(
-            input_data[min_load_ts]
-            .loc[
-                dm.start_time : dm.end_time,
-                min_load_column,
-            ]
-            .to_numpy(),
-            input_data[availability_ts].loc[
-                dm.start_time : dm.end_time, "values"
-            ].to_numpy() - 0.01
-        )
+    outflow_args_el["min"] = np.minimum(
+        input_data[min_load_ts]
+        .loc[
+            dm.start_time : dm.end_time,
+            min_load_column,
+        ]
+        .to_numpy(),
+        input_data[availability_ts]
+        .loc[dm.start_time : dm.end_time, "values"]
+        .to_numpy()
+        - 0.01,
     )
     outflow_args_el["positive_gradient"]["ub"] = (
         input_data[gradient_ts]

--- a/tests/test_subroutines.py
+++ b/tests/test_subroutines.py
@@ -260,10 +260,13 @@ class TestSubroutines:
             == 5
         )
         assert (
-            node_dict["DE_transformer_hardcoal_BNA0216a"]
-            .outputs[node_dict["DE_bus_el"]]
-            .min.max()
-            == 1.0
+            np.round(
+                node_dict["DE_transformer_hardcoal_BNA0216a"]
+                .outputs[node_dict["DE_bus_el"]]
+                .min.max(),
+                3,
+            )
+            == 0.985
         )
 
     def test_create_transformers_res(self):


### PR DESCRIPTION
Fixes that minimum and maximum output were able to exceed the given availability since the minimum load profile values for heat and ipp plants included values as high as 1.

Note that this might affect simulation results (not yet checked for).