### PR TITLE
Add solver command line options as optional argument

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,7 @@ control_parameters:
                 'NO1', 'NO2', 'NO3', 'NO4', 'NO5', 'PL',
                 'SE1', 'SE2', 'SE3', 'SE4']
     solver: "gurobi"
+    solver_commandline_options: False
     fuel_cost_pathway: "NZE"
     emissions_cost_pathway: "long-term"
     activate_emissions_limit: False
@@ -35,3 +36,11 @@ input_output_parameters:
 rolling_horizon_parameters:
     time_slice_length_wo_overlap_in_hours: 24
     overlap_in_hours: 12
+
+# 5) Set solver command line options (optional)
+solver_cmdline_options:
+    lpmethod: 4
+    preprocessing dual: -1
+    solutiontype: 2
+    threads: 12
+    barrier convergetol: 1.0e-6

--- a/pommesdispatch/cli.py
+++ b/pommesdispatch/cli.py
@@ -12,6 +12,7 @@ control_parameters:
                 'NO1', 'NO2', 'NO3', 'NO4', 'NO5', 'PL',
                 'SE1', 'SE2', 'SE3', 'SE4']
     solver: "gurobi"
+    solver_commandline_options: False
     fuel_cost_pathway: "NZE"
     emissions_cost_pathway: "long-term"
     activate_emissions_limit: False
@@ -38,7 +39,15 @@ input_output_parameters:
 # 4) Set rolling horizon parameters (optional)
 rolling_horizon_parameters:
     time_slice_length_wo_overlap_in_hours: 24
-    overlap_in_hours: 12"""
+    overlap_in_hours: 12
+
+# 5) Set solver command line options (optional)
+solver_cmdline_options:
+    lpmethod: 4
+    preprocessing dual: -1
+    solutiontype: 2
+    threads: 12
+    barrier convergetol: 1.0e-6"""
     with open("./config.yml", "w") as opf:
         opf.write(content)
 

--- a/pommesdispatch/model/dispatch_model.py
+++ b/pommesdispatch/model/dispatch_model.py
@@ -124,7 +124,20 @@ def run_dispatch_model(config_file="./config.yml"):
                 dm.path_folder_output + "pommesdispatch_model.lp",
                 io_options={"symbolic_solver_labels": True},
             )
-        dm.om.solve(solver=dm.solver, solve_kwargs={"tee": True})
+        if dm.solver_commandline_options:
+            logging.info(
+                "Using solver command line options.\n"
+                "Ensure that these are the correct ones for your solver of "
+                "choice since otherwise, this might lead to "
+                "the solver to run into an Error."
+            )
+            dm.om.solve(
+                solver=dm.solver,
+                solve_kwargs={"tee": True},
+                cmdline_options=config["solver_cmdline_options"],
+            )
+        else:
+            dm.om.solve(solver=dm.solver, solve_kwargs={"tee": True})
         meta_results = processing.meta_results(dm.om)
 
         power_prices = dm.get_power_prices_from_duals()

--- a/pommesdispatch/model_funcs/model_control.py
+++ b/pommesdispatch/model_funcs/model_control.py
@@ -70,6 +70,9 @@ class DispatchModel(object):
         Must be one of the solvers oemof.solph resp. pyomo support, e.g.
         'cbc', 'gplk', 'gurobi', 'cplex'.
 
+    solver_commandline_options: bool
+        If True, use solver command line option; If False, use solver defaults
+
     fuel_cost_pathway :  str
         A predefined pathway for commodity cost development until 2050
 
@@ -226,6 +229,7 @@ class DispatchModel(object):
         self.aggregate_input = None
         self.countries = None
         self.solver = None
+        self.solver_commandline_options = None
         self.fuel_cost_pathway = None
         self.emissions_cost_pathway = None
         self.activate_emissions_limit = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ class TestCli:
                     "SE4",
                 ],
                 "solver": "gurobi",
+                "solver_commandline_options": False,
                 "fuel_cost_pathway": "NZE",
                 "emissions_cost_pathway": "long-term",
                 "activate_emissions_limit": False,
@@ -62,6 +63,13 @@ class TestCli:
             "rolling_horizon_parameters": {
                 "time_slice_length_wo_overlap_in_hours": 24,
                 "overlap_in_hours": 12,
+            },
+            "solver_cmdline_options": {
+                "lpmethod": 4,
+                "preprocessing dual": -1,
+                "solutiontype": 2,
+                "threads": 12,
+                "barrier convergetol": 1e-6,
             },
         }
 

--- a/tests/test_model_control.py
+++ b/tests/test_model_control.py
@@ -32,6 +32,7 @@ def return_model_and_parameters():
             "SE4",
         ],
         "solver": "cbc",
+        "solver_commandline_options": False,
         "fuel_cost_pathway": "NZE",
         "emissions_cost_pathway": "long-term",
         "activate_emissions_limit": False,


### PR DESCRIPTION
Closes #43 
Introduces solver command line options which can be used as an optional keyword argument.

Note: Defaults specified apply for CPLEX solver on a HPC single node