### PR TITLE
Add config option for RES clusters and adjust file name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,7 @@ control_parameters:
     activate_demand_response: True
     demand_response_approach: "DLR"
     demand_response_scenario: "50"
+    eeg_clusters_per_technology: 20
     save_updated_market_values: True
     save_production_results: True
     save_price_results: True

--- a/pommesdispatch/model_funcs/data_input.py
+++ b/pommesdispatch/model_funcs/data_input.py
@@ -63,7 +63,10 @@ def parse_input_data(dm):
         "sources_renewables": "sources_renewables",
         "storages_el": "storages_el",
         "transformers": "transformers",
-        "transformers_renewables": "transformers_renewables",
+        "transformers_renewables": (
+            f"transformers_renewables_"
+            f"{dm.eeg_clusters_per_technology}_clusters"
+        ),
     }
 
     time_series = {

--- a/pommesdispatch/model_funcs/model_control.py
+++ b/pommesdispatch/model_funcs/model_control.py
@@ -179,6 +179,11 @@ class DispatchModel(object):
         Options: '25', '50', '75', whereby '25' is the lower,
         i.e. rather pessimistic estimate
 
+    eeg_clusters_per_technology : int
+        Maximum number of clusters per technology supported under the German
+        EEG and focused upon in pommesdispatch
+        (solar, wind onshore, wind offshore)
+
     save_updated_market_values : str
         boolean control variable indicating whether to save updated
         RES market values calculated from a previous model run
@@ -242,6 +247,7 @@ class DispatchModel(object):
         self.activate_demand_response = None
         self.demand_response_approach = None
         self.demand_response_scenario = None
+        self.eeg_clusters_per_technology = None
         self.save_updated_market_values = None
         self.save_production_results = None
         self.save_price_results = None
@@ -401,6 +407,9 @@ class DispatchModel(object):
             + "-days_"
             + rh
             + agg
+            + "_"
+            + str(self.eeg_clusters_per_technology)
+            + "_res-clusters"
         )
 
         setattr(self, "filename", filename)


### PR DESCRIPTION
* Add a config option for the maximum number of clusters per RES technology relevant under the German EEG
* Adjust input and output file names accordingly